### PR TITLE
workaround for wallet issues on android

### DIFF
--- a/pages/api/issue.js
+++ b/pages/api/issue.js
@@ -52,7 +52,7 @@ const credentialTypes = {
   },
   rewardsProgram({ holderDID }) {
     return {
-      name: 'Rewards Program',
+      name: 'Rewards Elegibility',
       type: ['VerifiableCredential', 'RewardsProgram'],
       issuer: issuerDID,
       subject: {


### PR DESCRIPTION
The wallet has a logic to prevent duplicated type and cred title to be displayed. It will fallback to the first attribute in the list. However it can't handle properly boolean attributes on this case. 

Pushing this PR to unblock a demo on the current release build. This issue will be fixed on the wallet side for the next releas
<img width="408" alt="image" src="https://github.com/docknetwork/dock-bank-demo/assets/12645078/0ca9c570-7f0c-4c03-8063-6625f909827e">

